### PR TITLE
hotfix: whitelabel exception page

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,11 @@
 server:
   error:
     include-message: always
-    whitelabel.enabled: false
+    whitelabel.enabled: true
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
   servlet:
     context-path: /search
     multipart:


### PR DESCRIPTION
- context url이 옮겨짐으로 발생한 순환 참조 오류 해결 => spring boot 기본 제공 error page 사용